### PR TITLE
fix prints and batchnorm

### DIFF
--- a/model.py
+++ b/model.py
@@ -402,7 +402,7 @@ class pix2pix(object):
         sample_images = [sample_images[i:i+self.batch_size]
                          for i in xrange(0, len(sample_images), self.batch_size)]
         sample_images = np.array(sample_images)
-        print sample_images.shape
+        print(sample_images.shape)
 
         start_time = time.time()
         if self.load(self.checkpoint_dir):
@@ -412,7 +412,7 @@ class pix2pix(object):
 
         for i, sample_image in enumerate(sample_images):
             idx = i+1
-            print "sampling image ", idx
+            print("sampling image ", idx)
             samples = self.sess.run(
                 self.fake_B_sample,
                 feed_dict={self.real_data: sample_image}

--- a/ops.py
+++ b/ops.py
@@ -7,42 +7,15 @@ from tensorflow.python.framework import ops
 from utils import *
 
 class batch_norm(object):
-    """Code modification of http://stackoverflow.com/a/33950177"""
+            # h1 = lrelu(tf.contrib.layers.batch_norm(conv2d(h0, self.df_dim*2, name='d_h1_conv'),decay=0.9,updates_collections=None,epsilon=0.00001,scale=True,scope="d_h1_conv"))
     def __init__(self, epsilon=1e-5, momentum = 0.9, name="batch_norm"):
         with tf.variable_scope(name):
             self.epsilon = epsilon
             self.momentum = momentum
-
-            self.ema = tf.train.ExponentialMovingAverage(decay=self.momentum)
             self.name = name
 
     def __call__(self, x, train=True):
-        shape = x.get_shape().as_list()
-
-        if train:
-            with tf.variable_scope(self.name) as scope:
-                self.beta = tf.get_variable("beta", [shape[-1]],
-                                    initializer=tf.constant_initializer(0.))
-                self.gamma = tf.get_variable("gamma", [shape[-1]],
-                                    initializer=tf.random_normal_initializer(1., 0.02))
-                
-                try:
-                    batch_mean, batch_var = tf.nn.moments(x, [0, 1, 2], name='moments')
-                except:
-                    batch_mean, batch_var = tf.nn.moments(x, [0, 1], name='moments')
-                    
-                ema_apply_op = self.ema.apply([batch_mean, batch_var])
-                self.ema_mean, self.ema_var = self.ema.average(batch_mean), self.ema.average(batch_var)
-
-                with tf.control_dependencies([ema_apply_op]):
-                    mean, var = tf.identity(batch_mean), tf.identity(batch_var)
-        else:
-            mean, var = self.ema_mean, self.ema_var
-
-        normed = tf.nn.batch_norm_with_global_normalization(
-                x, mean, var, self.beta, self.gamma, self.epsilon, scale_after_normalization=True)
-
-        return normed
+        return tf.contrib.layers.batch_norm(x, decay=self.momentum, updates_collections=None, epsilon=self.epsilon, scale=True, scope=self.name)
 
 def binary_cross_entropy(preds, targets, name=None):
     """Computes binary cross entropy given `preds`.


### PR DESCRIPTION
changed prints to functions where missing to work with python 3 and changed batchnorm function to work with tf 0.12 (see https://github.com/yenchenlin/pix2pix-tensorflow/issues/6).
i took the code from here: https://github.com/carpedm20/DCGAN-tensorflow/blob/master/utils.py
my previous pr was referencing the wrong source branch