### PR TITLE
Change image loading for grayscale support

### DIFF
--- a/model.py
+++ b/model.py
@@ -113,10 +113,8 @@ class pix2pix(object):
         data = np.random.choice(glob('./datasets/{}/val/*.jpg'.format(self.dataset_name)), self.batch_size)
         sample = [load_data(sample_file) for sample_file in data]
 
-        if (self.is_grayscale):
-            sample_images = np.array(sample).astype(np.float32)[:, :, :, None]
-        else:
-            sample_images = np.array(sample).astype(np.float32)
+        sample_images = np.array(sample).astype(np.float32)
+
         return sample_images
 
     def sample_model(self, sample_dir, epoch, idx):
@@ -160,10 +158,7 @@ class pix2pix(object):
             for idx in xrange(0, batch_idxs):
                 batch_files = data[idx*self.batch_size:(idx+1)*self.batch_size]
                 batch = [load_data(batch_file) for batch_file in batch_files]
-                if (self.is_grayscale):
-                    batch_images = np.array(batch).astype(np.float32)[:, :, :, None]
-                else:
-                    batch_images = np.array(batch).astype(np.float32)
+                batch_images = np.array(batch).astype(np.float32)
 
                 # Update D network
                 _, summary_str = self.sess.run([d_optim, self.d_sum],
@@ -404,10 +399,7 @@ class pix2pix(object):
         print("Loading testing images ...")
         sample = [load_data(sample_file, is_test=True) for sample_file in sample_files]
 
-        if (self.is_grayscale):
-            sample_images = np.array(sample).astype(np.float32)[:, :, :, None]
-        else:
-            sample_images = np.array(sample).astype(np.float32)
+        sample_images = np.array(sample).astype(np.float32)
 
         sample_images = [sample_images[i:i+self.batch_size]
                          for i in xrange(0, len(sample_images), self.batch_size)]

--- a/utils.py
+++ b/utils.py
@@ -24,7 +24,10 @@ def load_data(image_path, flip=True, is_test=False):
     img_A = img_A/127.5 - 1.
     img_B = img_B/127.5 - 1.
 
-    img_AB = np.concatenate((img_A, img_B), axis=2)
+    try:
+        img_AB = np.concatenate((img_A, img_B), axis=2)
+    except IndexError:
+        img_AB = np.dstack((img_A, img_B))
     # img_AB shape: (fine_size, fine_size, input_c_dim + output_c_dim)
     return img_AB
 


### PR DESCRIPTION
I tried training the model for grayscale input and was having similar issues as mentioned in #12, setting `input_c_dim=1` and `output_c_dim=1` did not work for me
```
model = pix2pix(sess, image_size=args.fine_size, batch_size=args.batch_size,
                        output_size=args.fine_size, dataset_name=args.dataset_name,
                        checkpoint_dir=args.checkpoint_dir, sample_dir=args.sample_dir,
                        input_c_dim=1, output_c_dim=1)
```

After investigating the issue, I changed the image loading function which made the optional reshaping
```
if (self.is_grayscale):
    batch_images = np.array(batch).astype(np.float32)[:, :, :, None]
else:
    batch_images = np.array(batch).astype(np.float32)
```
obsolete.
